### PR TITLE
fix 3d touch bug

### DIFF
--- a/Scout/ApplicationController.swift
+++ b/Scout/ApplicationController.swift
@@ -39,6 +39,7 @@ class ApplicationController: UINavigationController,  CLLocationManagerDelegate 
     
     fileprivate lazy var session: Session = {
         let session = Session(webViewConfiguration: self.webViewConfiguration)
+        session.webView.allowsLinkPreview = false
         session.delegate = self
         return session
     }()


### PR DESCRIPTION
* disables the use of 3d touch within the app.
* prevents hybrid  links from opening in safari using 3d touch