### PR TITLE
Removes self. from viewDidAppear and viewDidLoad methods to fix sessi…

### DIFF
--- a/Scout/ApplicationController.swift
+++ b/Scout/ApplicationController.swift
@@ -59,11 +59,11 @@ class ApplicationController: UINavigationController,  CLLocationManagerDelegate 
         super.viewDidLoad()
         
         // user location feature
-        /* self.setUserLocation()
+        /* setUserLocation()
         if (!CLLocationManager.locationServicesEnabled()) {
-            self.presentVisitableForSession(session, URL: URL)
+            presentVisitableForSession(session, URL: URL)
         } */
-        self.presentVisitableForSession(session, URL: URL)
+        presentVisitableForSession(session, URL: URL)
     }
 
     override func viewDidAppear(_ animated:Bool) {
@@ -77,14 +77,14 @@ class ApplicationController: UINavigationController,  CLLocationManagerDelegate 
         } else {
             // check to see if the campus or location has changed from what was previously set in session
             if (sessionURL!.lowercased().range(of: campus) == nil) {
-                self.presentVisitableForSession(session, URL: URL, action: .Replace)
+                presentVisitableForSession(session, URL: URL, action: .Replace)
             } else if ((CLLocationManager.locationServicesEnabled()) && (sessionURL!.lowercased().range(of: location) == nil)) {
                 presentVisitableForSession(session, URL: URL, action: .Replace)
             }
         }*/
         
         if (sessionURL!.lowercased().range(of: campus) == nil) {
-            self.presentVisitableForSession(session, URL: URL, action: .Replace)
+            presentVisitableForSession(session, URL: URL, action: .Replace)
         }
     }
     


### PR DESCRIPTION
On the latest build(7) of the iOS app... visiting a Turbolinks page and restoring a session causes the app to crash. 

Compared viewDidLoad() and ViewDidAppear() with previous working versions of the code... looks like presentVisitableForSession(session, URL: URL) was replaced with self.presentVisitableForSession(session, URL: URL)

self. seems to break session restorations. Reverting to the previous function call fixes the crash.
