### PR TITLE
Bug/filter actions

### DIFF
--- a/Scout/ApplicationController.swift
+++ b/Scout/ApplicationController.swift
@@ -13,9 +13,11 @@ import CoreLocation
 //import CoreMotion
 
 class ApplicationController: UINavigationController,  CLLocationManagerDelegate {
-
+    
+    // initialize location manager
     let locationManager = CLLocationManager()
     
+    // initial URL contstruction
     var URL: Foundation.URL {
         return Foundation.URL(string: "\(host)/\(campus)/\(location)")!
     }

--- a/Scout/FoodViewController.swift
+++ b/Scout/FoodViewController.swift
@@ -40,6 +40,7 @@ class FoodViewController: ApplicationController {
             
         } else if URL.path == "/h/\(campus)/food/filter" {
             
+            /**
             let backButton : UIBarButtonItem = UIBarButtonItem(image: UIImage(named: "BackButton"), style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
             let backButtonText : UIBarButtonItem = UIBarButtonItem(title: "Food", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
             
@@ -50,8 +51,13 @@ class FoodViewController: ApplicationController {
             visitable.navigationItem.leftBarButtonItem = backButtonText
             
             visitable.navigationItem.setLeftBarButtonItems([backButton, backButtonText], animated: true)
-
-            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Clear", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.clearFilter))
+            ***/
+            
+            visitable.navigationItem.hidesBackButton = true
+            
+            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Update", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
+            
+            visitable.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Clear", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.clearFilter))
             
         }
         

--- a/Scout/FoodViewController.swift
+++ b/Scout/FoodViewController.swift
@@ -40,24 +40,14 @@ class FoodViewController: ApplicationController {
             
         } else if URL.path == "/h/\(campus)/food/filter" {
             
-            /**
-            let backButton : UIBarButtonItem = UIBarButtonItem(image: UIImage(named: "BackButton"), style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
-            let backButtonText : UIBarButtonItem = UIBarButtonItem(title: "Food", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
-            
-            // fix spacing between back arrow and text
-            backButton.imageInsets = UIEdgeInsetsMake(0, -7.0, 0, -30.0)
-            
-            visitable.navigationItem.leftBarButtonItem = backButton
-            visitable.navigationItem.leftBarButtonItem = backButtonText
-            
-            visitable.navigationItem.setLeftBarButtonItems([backButton, backButtonText], animated: true)
-            ***/
-            
+            // hide the default back button
             visitable.navigationItem.hidesBackButton = true
             
-            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Update", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
-            
+            // left button to clear filters
             visitable.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Clear", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.clearFilter))
+
+            // right button to update filters
+            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Update", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
             
         }
         

--- a/Scout/StudyViewController.swift
+++ b/Scout/StudyViewController.swift
@@ -35,18 +35,14 @@ class StudyViewController: ApplicationController {
             
         } else if URL.path == "/h/\(campus)/study/filter" {
             
-            let backButton : UIBarButtonItem = UIBarButtonItem(image: UIImage(named: "BackButton"), style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
-            let backButtonText : UIBarButtonItem = UIBarButtonItem(title: "Study", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
+            // hide the default back button
+            visitable.navigationItem.hidesBackButton = true
             
-            // fix spacing between back arrow and text
-            backButton.imageInsets = UIEdgeInsetsMake(0, -7.0, 0, -30.0)
+            // left button to clear filters
+            visitable.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Clear", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.clearFilter))
             
-            visitable.navigationItem.leftBarButtonItem = backButton
-            visitable.navigationItem.leftBarButtonItem = backButtonText
-            
-            visitable.navigationItem.setLeftBarButtonItems([backButton,backButtonText], animated: true)
-            
-            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Clear", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.clearFilter))
+            // right button to update filters
+            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Update", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
             
         }
         

--- a/Scout/TechViewController.swift
+++ b/Scout/TechViewController.swift
@@ -35,19 +35,14 @@ class TechViewController: ApplicationController {
             
         } else if URL.path == "/h/\(campus)/tech/filter" {
             
-            let backButton : UIBarButtonItem = UIBarButtonItem(image: UIImage(named: "BackButton"), style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
-            let backButtonText : UIBarButtonItem = UIBarButtonItem(title: "Tech", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
+            // hide the default back button
+            visitable.navigationItem.hidesBackButton = true
             
-            // fix spacing between back arrow and text
-            backButton.imageInsets = UIEdgeInsetsMake(0, -7.0, 0, -30.0)
+            // left button to clear filters
+            visitable.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Clear", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.clearFilter))
             
-            visitable.navigationItem.leftBarButtonItem = backButton
-            visitable.navigationItem.leftBarButtonItem = backButtonText
-            
-            visitable.navigationItem.setLeftBarButtonItems([backButton,backButtonText], animated: true)
-            
-            
-            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Clear", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.clearFilter))
+            // right button to update filters
+            visitable.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Update", style: UIBarButtonItemStyle.plain, target: self, action: #selector(ApplicationController.submitFilter))
             
         }
         


### PR DESCRIPTION
This fix is related to the bug Jason filed about unclear filter submit behavior.

OLD (behavior):
On the filters pages, we build a custom back button and overlay it on top of the default back button. This custom button calls the submitFilter function which then pops the view controller back to the starting list and refreshes the view controller. 

NEW:
On the filters pages, we now just hide the default back button. 2 custom buttons now exist as both left and right buttons. Left performs the "clear" action. Right performs the "update" or submit action. This is much cleaner and less confusing to the user.
